### PR TITLE
feat: adding cyral output var repo_crawler_aws_security_group_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_repo_crawler_aws_security_group_id"></a> [repo\_crawler\_aws\_security\_group\_id](#output\_repo\_crawler\_aws\_security\_group\_id) | The Amazon Security Group ID of the Repo Crawler Lambda function. |
 | <a name="output_repo_crawler_lambda_function_arn"></a> [repo\_crawler\_lambda\_function\_arn](#output\_repo\_crawler\_lambda\_function\_arn) | The Amazon Resource Name (ARN) of the Repo Crawler Lambda function. |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "repo_crawler_lambda_function_arn" {
   value = aws_lambda_function.this.arn
   description = "The Amazon Resource Name (ARN) of the Repo Crawler Lambda function."
 }
+
+output "repo_crawler_aws_security_group_id" {
+  value = aws_security_group.this.id
+  description = "The Amazon Security Group ID of the Repo Crawler Lambda function."
+}


### PR DESCRIPTION
# Summary

* Adding the cyral security group id output terraform variable

# Details

This exposed the security group id used in the cyral module, without exposing this it makes it more difficult to discover when allowing cyral to talk to specific databases.

# Testing

* Ran locally in our environment