### PR TITLE
fix(variables): fixing proper default number type for repo_port

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -94,7 +94,7 @@ variable "repo_port" {
     The port of the database service in the database instance. If omitted, the value
     will be inferred from the Control Plane (crawler versions >= v0.9.0 only).
   EOF
-  default = ""
+  default = null
 }
 
 variable "repo_secret_arn" {


### PR DESCRIPTION
## Issue 
A recent commit to v0.2.0 introduced a breaking change where the type validation was enforced here: https://github.com/cyralinc/terraform-aws-repo-crawler/commit/1905e7f753667b22bf69115af6e4f3de0ffabf04#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR97

This fixes https://github.com/cyralinc/terraform-aws-repo-crawler/issues/6.

## Error results
```
╷
│ Error: Invalid default value for variable
│
│   on .terraform/modules/example.cyral_repo_crawler/variables.tf line 97, in variable "repo_port":
│   97:   default = ""
│
│ This default value is not compatible with the variable's type constraint: a number is required.
╵
```