### PR TITLE
ENG-12488: Change to provided.al2 runtime due to go1.x deprecation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -167,8 +167,8 @@ resource "aws_lambda_function" "this" {
   s3_bucket     = "cyral-public-assets-${data.aws_region.current.name}"
   s3_key        = "cyral-repo-crawler/${var.crawler_version}/cyral-repo-crawler-lambda-${var.crawler_version}.zip"
   timeout       = var.timeout
-  runtime       = "go1.x"
-  handler       = "crawler-lambda"
+  runtime       = "provided.al2"
+  handler       = "bootstrap"
 
   vpc_config {
     security_group_ids = [aws_security_group.this.id]


### PR DESCRIPTION
As title, in response to https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/